### PR TITLE
Be able to call a WASM module (compiled from AssemblyScript)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
 .direnv/*
 .envrc
+/target
 shell.nix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "lazy_static",
+ "serde",
+ "serde_json",
  "wasmer",
  "wasmer-as",
  "wasmer-compiler-cranelift",
@@ -82,9 +84,9 @@ checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f403a29df55aacacdef2114efafb10c7405e6b051d829f420c33918aeef0f8"
+checksum = "314889ea31cda264cb7c3d6e6e5c9415a987ecb0e72c17c00d36fbb881d34abe"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -92,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b4dff26fdc9f847dab475c9fec16f2cba82d5aa1f09981b87c44520721e10a"
+checksum = "4a2b3b92c135dae665a6f760205b89187638e83bed17ef3e44e83c712cf30600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -228,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -238,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
 dependencies = [
  "fnv",
  "ident_case",
@@ -252,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
  "darling_core",
  "quote",
@@ -364,6 +366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,9 +394,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "8e167738f1866a7ec625567bae89ca0d44477232a4f7c52b1c7f2adc2c98804f"
 
 [[package]]
 name = "libloading"
@@ -456,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -544,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]
@@ -688,18 +696,18 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a97e3d54c72a2837a552c9ca99e7163ed7892f0f70cc5372a0aec9e9b7c152"
+checksum = "1033f6fe7ce48c8333e5412891b933e85d6a3a09728c4883240edf64e7a6f11a"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "rkyv"
-version = "0.7.24"
+version = "0.7.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1460b2dd43a8416140f3fdcd8dc76cb67f01f58d0db648ec9ae71ee375942174"
+checksum = "66bf572c17c77322f4d858c214def56b13a3c32b8d833cd6d28a92de8325ac5f"
 dependencies = [
  "bytecheck",
  "hashbrown",
@@ -711,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.24"
+version = "0.7.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d4f9c7215fac8b7ef54171e14cc18875821178fe8b99fb2f85e211d8bdda40"
+checksum = "df3eca50f172b8e59e2080810fb41b65f047960c197149564d4bd0680af1888e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -734,9 +742,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "scopeguard"
@@ -752,9 +766,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
 dependencies = [
  "serde_derive",
 ]
@@ -770,13 +784,24 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 lazy_static = "1"
+serde = "1.0"
+serde_json = "1.0"
 wasmer = "2.0.0"
 wasmer-as = { git = "https://github.com/adrien-zinger/wasmer-as", tag = "v0.1.0" }
 wasmer-compiler-cranelift = "2"

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,8 +1,7 @@
+//! Extends the env of wasmer-as
+
 use crate::types::Interface;
 use anyhow::Result;
-/// Extends the env of wasmer-as
-///
-///
 use wasmer::{HostEnvInitError, Instance, WasmerEnv};
 use wasmer_as::{Read, StringPtr};
 use wasmer_middlewares::metering::{self, set_remaining_points, MeteringPoints};
@@ -53,8 +52,14 @@ pub fn sub_remaining_point(env: &Env, points: u64) -> anyhow::Result<()> {
     Ok(())
 }
 
-// if get_string throws an exception abort for some reason is being called
-pub fn abort(env: &Env, message: StringPtr, filename: StringPtr, line: i32, col: i32) {
+/// if get_string throws an exception abort for some reason is being called
+pub fn assembly_script_abort(
+    env: &Env,
+    message: StringPtr,
+    filename: StringPtr,
+    line: i32,
+    col: i32,
+) {
     let memory = env.wasm_env.memory.get_ref().expect("initialized memory");
     let message = message.read(memory).unwrap();
     let filename = filename.read(memory).unwrap();

--- a/src/execution_impl.rs
+++ b/src/execution_impl.rs
@@ -79,11 +79,10 @@ pub fn assembly_script_call_module(env: &Env, address: i32, function: i32) -> i3
 /// An utility print function to write on stdout directly from AssemblyScript:
 pub fn assembly_script_print(env: &Env, arg: i32) {
     let str_ptr = StringPtr::new(arg as u32);
-    // TODO: may be in wasmer-as create a pointer that keep memory?
     println!(
         "{}",
         str_ptr
-            .read(env.wasm_env.memory.get_ref().expect("initialized memory"))
+            .read(env.wasm_env.memory.get_ref().expect("uninitialized memory"))
             .unwrap()
     );
 }

--- a/src/execution_impl.rs
+++ b/src/execution_impl.rs
@@ -145,22 +145,6 @@ pub fn exec(
     }
 }
 
-// TODO: @adrien-zinger the difference between `update_and_run`, `run` and
-// `exec` was not obvious for me ... could we consider a better naming/add doc
-// comments?
-pub fn update_and_run(
-    address: Address,
-    module: &[u8],
-    limit: u64,
-    interface: &Interface,
-) -> Result<u64> {
-    let update_module: fn(address: &Address, module: &Bytecode) -> Result<()> =
-        interface.update_module;
-    update_module(&address, &module.to_vec())?;
-    println!("Module inserted by {}", address);
-    run(module, limit, interface)
-}
-
 pub fn run(module: &[u8], limit: u64, interface: &Interface) -> Result<u64> {
     let instance = create_instance(limit, module, interface)?;
     if instance.exports.contains(settings::MAIN) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,7 @@
-mod env;
-mod execution_impl;
-mod settings;
-
+pub mod env;
+pub mod execution_impl;
+pub mod settings;
 pub mod types;
-
-pub use execution_impl::run;
-pub use execution_impl::update_and_run;
-pub use types::Interface;
 
 #[cfg(test)]
 mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::execution_impl::run;
-use crate::execution_impl::update_and_run;
 use crate::settings::METERING;
+use crate::types::Address;
+use crate::types::Bytecode;
 use crate::types::Interface;
 use crate::types::Ledger;
 use anyhow::bail;
@@ -31,8 +32,10 @@ fn test_caller() {
         env!("CARGO_MANIFEST_DIR"),
         "/wasm/build/get_string.wat"
     ));
-    update_and_run("get_string.wat".to_string(), module, 100, interface)
-        .expect("Failed to run get_string.wat");
+    let update_module: fn(address: &Address, module: &Bytecode) -> anyhow::Result<()> =
+        interface.update_module;
+    update_module(&"get_string.wat".to_string(), &module.to_vec()).unwrap();
+    run(module, 100, interface).expect("Failed to run get_string.wat");
     let module = include_bytes!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/wasm/build/caller.wat"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,8 @@
-use crate::run;
+use crate::execution_impl::run;
+use crate::execution_impl::update_and_run;
 use crate::settings::METERING;
 use crate::types::Interface;
 use crate::types::Ledger;
-use crate::update_and_run;
 use anyhow::bail;
 use std::sync::Mutex;
 


### PR DESCRIPTION
Be able to call a WASM module (compiled from AssemblyScript) using high-level Rust types (by de/serializing a String).

The intend is to be able to expose any kind of function as an ABI:
```rust
fn get_status() -> Result<NodeStatus> {
     Ok(typed_call(env, "0xAddressOfSCInLedger", "get_status", ())?)
}
```