### PR TITLE
:chart_with_upwards_trend:  For a better coverage, don't test dependencies & interface

### DIFF
--- a/.github/action-rs/grcov.yml
+++ b/.github/action-rs/grcov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "../*"
+  - "src/types.rs"


### PR DESCRIPTION
We don't want to be dependent of the coverage of cargo dependencies so we ignore the path "../"
And then we also skip the types.rs that contains declaration of interface. It's better than just test if we bail.